### PR TITLE
Dead letter topics

### DIFF
--- a/_infra/helm/csv-worker/Chart.yaml
+++ b/_infra/helm/csv-worker/Chart.yaml
@@ -18,4 +18,4 @@ version: 1.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 1.0.6
+appVersion: 1.0.7

--- a/worker/main.go
+++ b/worker/main.go
@@ -43,6 +43,11 @@ func (cw CSVWorker) subscribe(ctx context.Context, client *pubsub.Client) {
 	err := sub.Receive(cctx, func(ctx context.Context, msg *pubsub.Message) {
 		log.Info("sample received - processing")
 		log.WithField("data", string(msg.Data)).Debug("sample data")
+
+		if msg.DeliveryAttempt != nil {
+			log.WithField("delivery attempts", *msg.DeliveryAttempt).Info("Message delivery attempted")
+		}
+
 		sample := msg.Data
 		attribute := msg.Attributes
 		sampleSummaryId, ok := attribute["sample_summary_id"]
@@ -51,16 +56,15 @@ func (cw CSVWorker) subscribe(ctx context.Context, client *pubsub.Client) {
 			err := processSample(sample, sampleSummaryId)
 			if err != nil {
 				log.WithError(err).Error("error processing sample - nacking message")
+				//after x number of nacks message will be DLQ
 				msg.Nack()
 			} else {
 				log.Info("sample processed - acking message")
 				msg.Ack()
 			}
 		} else {
-			log.Error("missing sample summary id - dropping message")
-			//TODO dead letter queue this but for now drop the message
-			msg.Ack()
-
+			log.Error("missing sample summary id - sending to DLQ")
+			deadLetter(ctx, client, msg)
 		}
 	})
 
@@ -70,8 +74,24 @@ func (cw CSVWorker) subscribe(ctx context.Context, client *pubsub.Client) {
 	}
 }
 
+// send message to DLQ immediately
+func deadLetter(ctx context.Context, client *pubsub.Client,msg *pubsub.Message) {
+	//DLQ are always named TOPIC + -dead-letter in our terraform scripts
+	deadLetterTopic := viper.GetString("PUB_SUB_TOPIC") + "-dead-letter"
+	dlq := client.Topic(deadLetterTopic)
+	id, err := dlq.Publish(ctx, msg).Get(ctx)
+	if err != nil {
+		log.WithField("msg", string(msg.Data)).WithError(err).Error("unable to forward to dead letter topic")
+		msg.Nack()
+	}
+	log.WithField("id", id).Info("published to dead letter topic")
+
+}
+
 func setDefaults() {
+
 	viper.SetDefault("PUBSUB_SUB_ID", "sample-workers")
+	viper.SetDefault("PUB_SUB_TOPIC", "sample-jobs")
 	viper.SetDefault("GOOGLE_CLOUD_PROJECT", "rm-ras-sandbox")
 	viper.SetDefault("WORKERS", "10")
 	viper.SetDefault("VERBOSE", true)
@@ -83,12 +103,16 @@ func work() {
 	csvWorker.start()
 }
 
-func main() {
-	log.Info("starting")
+func configure() {
 	//config
 	viper.AutomaticEnv()
 	setDefaults()
 	configureLogging()
+}
+
+func main() {
+	log.Info("starting")
+	configure()
 
 	workers := viper.GetInt("WORKERS")
 	for i := 0; i < workers; i++ {

--- a/worker/main.go
+++ b/worker/main.go
@@ -8,7 +8,7 @@ import (
 	"os"
 )
 
-type CSVWorker struct {}
+type CSVWorker struct{}
 
 func configureLogging() {
 	verbose := viper.GetBool("VERBOSE")
@@ -50,7 +50,7 @@ func (cw CSVWorker) subscribe(ctx context.Context, client *pubsub.Client) {
 		sample := msg.Data
 		attribute := msg.Attributes
 		sampleSummaryId, ok := attribute["sample_summary_id"]
-		if ok  {
+		if ok {
 			log.WithField("sampleSummaryId", sampleSummaryId).Info("about to process sample")
 			err := processSample(sample, sampleSummaryId)
 			if err != nil {

--- a/worker/main_test.go
+++ b/worker/main_test.go
@@ -19,7 +19,7 @@ import (
 var (
 	sample = "13110000001:::::::::::WW:::::OFFICE FOR NATIONAL STATISTICS:::::::::0001:"
 	client *pubsub.Client
-	ctx context.Context
+	ctx    context.Context
 )
 
 func TestMain(m *testing.M) {
@@ -39,7 +39,6 @@ func TestMain(m *testing.M) {
 
 	os.Exit(m.Run())
 }
-
 
 func TestSubscribe(t *testing.T) {
 	assert := assert.New(t)

--- a/worker/main_test.go
+++ b/worker/main_test.go
@@ -16,26 +16,44 @@ import (
 	"time"
 )
 
-func TestSubscribe(t *testing.T) {
-	assert := assert.New(t)
+var (
+	client *pubsub.Client
+	ctx context.Context
+)
+
+func TestMain(m *testing.M) {
+
 	//create a fake Pub Sub serer
-	ctx := context.Background()
+	ctx = context.Background()
 	// Start a fake server running locally.
 	srv := pstest.NewServer()
 	defer srv.Close()
 	// Connect to the server without using TLS.
-	conn, err := grpc.Dial(srv.Addr, grpc.WithInsecure())
-	assert.Nil(err)
+	conn, _ := grpc.Dial(srv.Addr, grpc.WithInsecure())
+
 	defer conn.Close()
 	// Use the connection when creating a pubsub client.
-	client, err := pubsub.NewClient(ctx, "rm-ras-sandbox", option.WithGRPCConn(conn))
-	assert.Nil(err)
+	client, _ = pubsub.NewClient(ctx, "rm-ras-sandbox", option.WithGRPCConn(conn))
 	defer client.Close()
 
-	topic, err := client.CreateTopic(ctx, "test")
+	os.Exit(m.Run())
+}
+
+
+func TestSubscribe(t *testing.T) {
+	assert := assert.New(t)
+
+	topic, err := client.CreateTopic(ctx, "sample-jobs")
 	assert.Nil(err)
 	assert.NotNil(topic)
 	fmt.Println(topic)
+	defer topic.Delete(ctx)
+
+	dlqTopic, err := client.CreateTopic(ctx, "sample-jobs-dead-letter")
+	assert.Nil(err)
+	assert.NotNil(topic)
+	fmt.Println(topic)
+	defer dlqTopic.Delete(ctx)
 
 	sub, err := client.CreateSubscription(ctx, "sample-workers", pubsub.SubscriptionConfig{
 		Topic: topic,
@@ -43,6 +61,92 @@ func TestSubscribe(t *testing.T) {
 	assert.Nil(err)
 	assert.NotNil(sub)
 	fmt.Println(sub)
+	defer sub.Delete(ctx)
+
+	dlqTopicSub, err := client.CreateSubscription(ctx, "sample-jobs-dead-letter", pubsub.SubscriptionConfig{
+		Topic: dlqTopic,
+	})
+	assert.Nil(err)
+	assert.NotNil(sub)
+	fmt.Println(sub)
+	defer dlqTopicSub.Delete(ctx)
+
+	sample := "13110000001:::::::::::WW:::::OFFICE FOR NATIONAL STATISTICS:::::::::0001:"
+
+	s := parse([]byte(sample))
+	sampleJson, err := s.marshall()
+	assert.Nil(err)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := ioutil.ReadAll(r.Body)
+		assert.Nil(err)
+		assert.Equal(sampleJson, body)
+		w.WriteHeader(http.StatusCreated)
+		w.Write([]byte("OK"))
+	}))
+
+	defer ts.Close()
+
+	fmt.Printf("Setting sample service base url %v", ts.URL)
+	err = os.Setenv("SAMPLE_SERVICE_BASE_URL", ts.URL)
+	assert.Nil(err)
+
+	msg := &pubsub.Message{
+		Data: []byte(sample),
+		Attributes: map[string]string{
+			"sample_summary_id":   "test",
+		},
+	}
+
+	id, err := topic.Publish(ctx, msg).Get(ctx)
+	assert.Nil(err)
+	fmt.Println(id)
+
+	worker := CSVWorker{}
+	configure()
+	go worker.subscribe(ctx, client)
+
+	var dlqMsgData []byte
+	go dlqTopicSub.Receive(ctx, func(ctx context.Context, dlqMsg *pubsub.Message) {
+		dlqMsgData = dlqMsg.Data
+	})
+	//sleep a second for the test to complete, then allow everything to shut down
+	time.Sleep(1 * time.Second)
+
+	//nothing should be on the DLW
+	assert.Nil(dlqMsgData)
+}
+
+func TestDeadletter(t *testing.T) {
+	assert := assert.New(t)
+
+	topic, err := client.CreateTopic(ctx, "sample-jobs")
+	assert.Nil(err)
+	assert.NotNil(topic)
+	fmt.Println(topic)
+	defer topic.Delete(ctx)
+
+	dlqTopic, err := client.CreateTopic(ctx, "sample-jobs-dead-letter")
+	assert.Nil(err)
+	assert.NotNil(topic)
+	fmt.Println(topic)
+	defer dlqTopic.Delete(ctx)
+
+	sub, err := client.CreateSubscription(ctx, "sample-workers", pubsub.SubscriptionConfig{
+		Topic: topic,
+	})
+	assert.Nil(err)
+	assert.NotNil(sub)
+	fmt.Println(sub)
+	defer sub.Delete(ctx)
+
+	dlqTopicSub, err := client.CreateSubscription(ctx, "sample-jobs-dead-letter", pubsub.SubscriptionConfig{
+		Topic: dlqTopic,
+	})
+	assert.Nil(err)
+	assert.NotNil(sub)
+	fmt.Println(sub)
+	defer dlqTopicSub.Delete(ctx)
 
 	sample := "13110000001:::::::::::WW:::::OFFICE FOR NATIONAL STATISTICS:::::::::0001:"
 
@@ -73,8 +177,17 @@ func TestSubscribe(t *testing.T) {
 	fmt.Println(id)
 
 	worker := CSVWorker{}
+	configure()
 	go worker.subscribe(ctx, client)
 
+	var dlqMsgData []byte
+	go dlqTopicSub.Receive(ctx, func(ctx context.Context, dlqMsg *pubsub.Message) {
+		assert.NotNil(dlqMsg)
+		assert.Equal(msg.Data, dlqMsg.Data)
+		dlqMsgData = dlqMsg.Data
+	})
 	//sleep a second for the test to complete, then allow everything to shut down
 	time.Sleep(1 * time.Second)
+
+	assert.NotNil(dlqMsgData)
 }

--- a/worker/sample_test.go
+++ b/worker/sample_test.go
@@ -5,18 +5,12 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"testing"
 
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestMain(m *testing.M) {
-
-	// call flag.Parse() here if TestMain uses flags
-	os.Exit(m.Run())
-}
 
 func TestSampleSuccess(t *testing.T) {
 	assert := assert.New(t)

--- a/worker/sample_test.go
+++ b/worker/sample_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-
 func TestSampleSuccess(t *testing.T) {
 	assert := assert.New(t)
 	ts := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Move messages to the dead letter topic if they don't contain a sample summary id. Message will also be automatically moved to the dead letter topic if they are nack multiple times (currently set to 10 in terraform).