### PR TITLE
replace deprecated cmd in GitHub Actions

### DIFF
--- a/.github/workflows/comment.yml
+++ b/.github/workflows/comment.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: set namespace
         run: |
-          echo ::set-env name=NAMESPACE::$(echo ${{ github.event.comment.body }} | cut -d' ' -f2)
+          echo NAMESPACE=$(echo ${{ github.event.comment.body }} | cut -d' ' -f2) >> $GITHUB_ENV
 
       - uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: package helm
         run: |
-          echo ::set-env name=HELM_VERSION::$(grep -E "version:\s+" $CHART_DIRECTORY/Chart.yaml | cut -d" " -f2 | sed -r 's/"//g')
+          echo HELM_VERSION=$(grep -E "version:\s+" $CHART_DIRECTORY/Chart.yaml | cut -d" " -f2 | sed -r 's/"//g') >> $GITHUB_ENV
           helm dep up $CHART_DIRECTORY
           helm package $CHART_DIRECTORY
 

--- a/_infra/helm/csv-worker/Chart.yaml
+++ b/_infra/helm/csv-worker/Chart.yaml
@@ -18,4 +18,4 @@ version: 1.0.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 1.0.11
+appVersion: 1.0.12


### PR DESCRIPTION
Replacing set-env command in GH Actions, disabled this week for security reasons.

- https://trello.com/c/5Pj2VUx5