### PR TITLE
Disabling Zap Drivers sampling configuration when in verbose mode

### DIFF
--- a/_infra/helm/csv-worker/Chart.yaml
+++ b/_infra/helm/csv-worker/Chart.yaml
@@ -18,4 +18,4 @@ version: 1.0.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 1.0.19
+appVersion: 1.0.20

--- a/main.go
+++ b/main.go
@@ -21,6 +21,8 @@ func configureLogging() {
 	if verbose {
 		config := zapdriver.NewProductionConfig()
 		config.Level = zap.NewAtomicLevelAt(zap.DebugLevel)
+		// disable sampling to ensure we get all log messages
+		config.Sampling = nil
 		logger, err = config.Build()
 		if err != nil {
 			panic(err)


### PR DESCRIPTION
By default Zap Driver has built in sampling configuration which reduces load on the CPU by logging a subset of all messages.

This PR disables that so that we get all log messages in stack driver


https://github.com/uber-go/zap/issues/588