### PR TITLE
Docker tag latest at the same time as the release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,9 +7,6 @@ on:
       - _infra/spinnaker/**
   pull_request:
     branches: [ main ]
-    paths-ignore:
-      - _infra/spinnaker/**
-      - _infra/helm/csv-worker/Chart.yaml
 
 env:
   IMAGE: csv-worker
@@ -129,11 +126,12 @@ jobs:
       - name: Build Release Image
         if: github.ref == 'refs/heads/main'
         run: |
-          docker build -t "$REGISTRY_HOSTNAME"/"$RELEASE_HOST"/"$IMAGE":${{ steps.release.outputs.version }} .
+          docker build -t "$REGISTRY_HOSTNAME"/"$RELEASE_HOST"/"$IMAGE":latest -t "$REGISTRY_HOSTNAME"/"$RELEASE_HOST"/"$IMAGE":${{ steps.release.outputs.version }} .
       - name: Push Release image
         if: github.ref == 'refs/heads/main'
         run: |
           docker push "$REGISTRY_HOSTNAME"/"$RELEASE_HOST"/"$IMAGE":${{ steps.release.outputs.version }}
+          docker push "$REGISTRY_HOSTNAME"/"$RELEASE_HOST"/"$IMAGE":latest
 
       - name: Publish Charts
         if: github.ref == 'refs/heads/main'

--- a/_infra/helm/csv-worker/Chart.yaml
+++ b/_infra/helm/csv-worker/Chart.yaml
@@ -18,4 +18,4 @@ version: 1.0.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 1.0.26
+appVersion: 1.0.27


### PR DESCRIPTION
# What and why?
During the release step tag the generated docker image as both the release version and latest.

# How to test?

# Trello
