### PR TITLE
Call party service

### DIFF
--- a/_infra/helm/csv-worker/Chart.yaml
+++ b/_infra/helm/csv-worker/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.0.1
+version: 1.0.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/_infra/helm/csv-worker/Chart.yaml
+++ b/_infra/helm/csv-worker/Chart.yaml
@@ -18,4 +18,4 @@ version: 1.0.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 1.0.27
+appVersion: 1.0.28

--- a/_infra/helm/csv-worker/templates/deployment.yaml
+++ b/_infra/helm/csv-worker/templates/deployment.yaml
@@ -57,5 +57,15 @@ spec:
             value: /var/secrets/google/credentials.json
           - name: GOOGLE_CLOUD_PROJECT
             value: {{ .Values.gcp.project }}
+          - name: SECURITY_USER_NAME
+            valueFrom:
+              secretKeyRef:
+                name: security-credentials
+                key: security-user
+          - name: SECURITY_USER_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: security-credentials
+                key: security-password
           resources:
             {{ toYaml .Values.resources | nindent 12 }}

--- a/_infra/helm/csv-worker/templates/deployment.yaml
+++ b/_infra/helm/csv-worker/templates/deployment.yaml
@@ -45,6 +45,12 @@ spec:
             {{- else }}
             value: "http://$(SAMPLE_SERVICE_HOST):$(SAMPLE_SERVICE_PORT)"
             {{- end }}
+          - name: PARTY_SERVICE_BASE_URL
+            {{- if .Values.dns.enabled }}
+            value: "http://party.{{ .Values.namespace }}.svc.cluster.local:{{ .Values.dns.wellKnownPort }}"
+            {{- else }}
+            value: "http://$(PARTY_SERVICE_HOST):$(PARTY_SERVICE_PORT)"
+            {{- end }}
           - name: VERBOSE
             value: {{.Values.verbose | quote }}
           - name: GOOGLE_APPLICATION_CREDENTIALS

--- a/main.go
+++ b/main.go
@@ -73,14 +73,14 @@ func (cw CSVWorker) subscribe(ctx context.Context, client *pubsub.Client) {
 				//after x number of nacks message will be DLQ
 				msg.Nack()
 			} else {
-				//now the sample has been create, lets create the associated party
+				//now the sample has been created, lets create the associated party
 				err := processParty(line, sampleSummaryId, sampleUnitId, msg)
 				if err != nil {
 					logger.Error("error processing party - nacking message", zap.Error(err))
 					//after x number of nacks message will be DLQ
 					msg.Nack()
 				}
-				logger.Info("sampel processed - acking message")
+				logger.Info("sample processed - acking message")
 				msg.Ack()
 			}
 		} else {

--- a/main.go
+++ b/main.go
@@ -77,7 +77,7 @@ func (cw CSVWorker) subscribe(ctx context.Context, client *pubsub.Client) {
 					//after x number of nacks message will be DLQ
 					msg.Nack()
 				}
-				logger.Info("sample processed - acking message")
+				logger.Info("sampel processed - acking message")
 				msg.Ack()
 			}
 		} else {

--- a/main.go
+++ b/main.go
@@ -118,6 +118,8 @@ func setDefaults() {
 	viper.SetDefault("VERBOSE", true)
 	viper.SetDefault("SAMPLE_SERVICE_BASE_URL", "http://localhost:8080")
 	viper.SetDefault("PARTY_SERVICE_BASE_URL", "http://localhost:8080")
+	viper.SetDefault("SECURITY_USER_NAME", "admin")
+	viper.SetDefault("SECURITY_USER_PASSWORD", "secret")
 }
 
 func work() {

--- a/main.go
+++ b/main.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"bytes"
 	"cloud.google.com/go/pubsub"
 	"context"
+	"encoding/csv"
 	"github.com/blendle/zapdriver"
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
@@ -59,19 +61,20 @@ func (cw CSVWorker) subscribe(ctx context.Context, client *pubsub.Client) {
 			logger.Info("Message delivery attempted", zap.Int("delivery attempts", *msg.DeliveryAttempt))
 		}
 
-		sample := msg.Data
+		data := msg.Data
 		attribute := msg.Attributes
 		sampleSummaryId, ok := attribute["sample_summary_id"]
 		if ok {
 			logger.Info("about to process sample", zap.String("sampleSummaryId", sampleSummaryId))
-			sampleUnitId, err := processSample(sample, sampleSummaryId, msg)
+			line := readSampleLine(data)
+			sampleUnitId, err := processSample(line, sampleSummaryId, msg)
 			if err != nil {
 				logger.Error("error processing sample - nacking message", zap.Error(err))
 				//after x number of nacks message will be DLQ
 				msg.Nack()
 			} else {
 				//now the sample has been create, lets create the associated party
-				err := processParty(sample, sampleSummaryId, sampleUnitId, msg)
+				err := processParty(line, sampleSummaryId, sampleUnitId, msg)
 				if err != nil {
 					logger.Error("error processing party - nacking message", zap.Error(err))
 					//after x number of nacks message will be DLQ
@@ -93,6 +96,19 @@ func (cw CSVWorker) subscribe(ctx context.Context, client *pubsub.Client) {
 		logger.Error("error subscribing")
 		cancel()
 	}
+}
+
+func readSampleLine(line []byte) []string {
+	logger.Debug("reading csv line")
+	r := csv.NewReader(bytes.NewReader(line))
+	r.Comma = ':'
+
+	sample, err := r.Read()
+	if err != nil {
+		logger.Fatal("unable to parse sample csv", zap.Error(err))
+	}
+	logger.Debug("read sample", zap.Strings("sample", sample))
+	return sample
 }
 
 // send message to DLQ immediately

--- a/main_test.go
+++ b/main_test.go
@@ -63,7 +63,7 @@ func TestSubscribe(t *testing.T) {
 		assert.Nil(err)
 		assert.Equal(sampleJson, body)
 		w.WriteHeader(http.StatusCreated)
-		w.Write([]byte("OK"))
+		w.Write([]byte("{\"id\":\"1111\"}"))
 	}))
 
 	defer ts.Close()
@@ -168,7 +168,7 @@ func TestDeadletterAsSampleSummaryIdMissing(t *testing.T) {
 		assert.Nil(err)
 		assert.Equal(sampleJson, body)
 		w.WriteHeader(http.StatusCreated)
-		w.Write([]byte("OK"))
+		w.Write([]byte("{\"id\":\"1111\"}"))
 	}))
 
 	defer ts.Close()

--- a/main_test.go
+++ b/main_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 var (
-	sample = "13110000001:::::::::::WW:::::OFFICE FOR NATIONAL STATISTICS:::::::::0001:"
+	line = "13110000001:::::::::::WW:::::OFFICE FOR NATIONAL STATISTICS:::::::::0001:"
 	client *pubsub.Client
 	ctx    context.Context
 )
@@ -73,7 +73,7 @@ func TestSubscribe(t *testing.T) {
 	assert.Nil(err)
 
 	msg := &pubsub.Message{
-		Data: []byte(sample),
+		Data: []byte(line),
 		Attributes: map[string]string{
 			"sample_summary_id": "test",
 		},
@@ -100,7 +100,8 @@ func TestSubscribe(t *testing.T) {
 }
 
 func parseSample(err error, assert *assert.Assertions) []byte {
-	s := parse([]byte(sample))
+	sample := readSampleLine([]byte(line))
+	s := create(sample)
 	sampleJson, err := s.marshall()
 	assert.Nil(err)
 	return sampleJson
@@ -157,7 +158,8 @@ func TestDeadletterAsSampleSummaryIdMissing(t *testing.T) {
 	dlqTopicSub := createDLQSubscription(err, dlqTopic, assert, sub)
 	defer dlqTopicSub.Delete(ctx)
 
-	s := parse([]byte(sample))
+	sample := readSampleLine([]byte(line))
+	s := create(sample)
 	sampleJson, err := s.marshall()
 	assert.Nil(err)
 
@@ -176,7 +178,7 @@ func TestDeadletterAsSampleSummaryIdMissing(t *testing.T) {
 	assert.Nil(err)
 
 	msg := &pubsub.Message{
-		Data: []byte(sample),
+		Data: []byte(line),
 		ID:   "1",
 	}
 

--- a/party.go
+++ b/party.go
@@ -3,110 +3,98 @@ package main
 import (
 	"bytes"
 	"cloud.google.com/go/pubsub"
-	"encoding/csv"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
 	"io/ioutil"
 	"net/http"
-	"fmt"
-	"errors"
 	"strconv"
 )
 
 type Party struct {
-	SAMPLEUNITREF string `json:"sampleUnitRef"`
-	SAMPLESUMMARYID string `json:"sampleSummaryId"`
-	SAMPLEUNITTYPE string `json:"sampleUnitType""`
-	Attributes 		Attributes `json:"attributes""`
+	SAMPLEUNITREF   string          `json:"sampleUnitRef"`
+	SAMPLESUMMARYID string          `json:"sampleSummaryId"`
+	SAMPLEUNITTYPE  string          `json:"sampleUnitType""`
+	Attributes      Attributes      `json:"attributes""`
 	msg             *pubsub.Message `json:"-"`
 }
 
 type Attributes struct {
-	CHECKLETTER   string `json:"checkletter"`
-	FROSIC92      string `json:"frosic92"`
-	RUSIC92       string `json:"rusic92"`
-	FROSIC2007    string `json:"frosic2007"`
-	RUSIC2007     string `json:"rusic2007"`
-	FROEMPMENT    int `json:"froempment"`
-	FROTOVER      int `json:"frotover"`
-	ENTREF        string `json:"entref"`
-	LEGALSTATUS   string `json:"legalstatus"`
-	NAME		  string `json:"name"`
-	ENTREPMKR     string `json:"entrepmkr"`
-	REGION        string `json:"region"`
-	BIRTHDATE     string `json:"birthdate"`
-	ENTNAME1      string `json:"entname1"`
-	ENTNAME2      string `json:"entname2"`
-	ENTNAME3      string `json:"entname3"`
-	RUNAME1       string `json:"runame1"`
-	RUNAME2       string `json:"runame2"`
-	RUNAME3       string `json:"runame3"`
-	TRADSTYLE1    string `json:"tradstyle1"`
-	TRADSTYLE2    string `json:"tradstyle2"`
-	TRADSTYLE3    string `json:"tradstyle3"`
-	SELTYPE       string `json:"seltype"`
-	INCLEXCL      string `json:"inclexcl"`
-	CELLNO        int `json:"cellNo"`
-	FORMTYPE      string `json:"formType"`
-	CURRENCY      string `json:"currency"`
-	SAMPLEUNITID  string `json:"sampleUnitRef"`
-
+	CHECKLETTER  string `json:"checkletter"`
+	FROSIC92     string `json:"frosic92"`
+	RUSIC92      string `json:"rusic92"`
+	FROSIC2007   string `json:"frosic2007"`
+	RUSIC2007    string `json:"rusic2007"`
+	FROEMPMENT   int    `json:"froempment"`
+	FROTOVER     int    `json:"frotover"`
+	ENTREF       string `json:"entref"`
+	LEGALSTATUS  string `json:"legalstatus"`
+	NAME         string `json:"name"`
+	ENTREPMKR    string `json:"entrepmkr"`
+	REGION       string `json:"region"`
+	BIRTHDATE    string `json:"birthdate"`
+	ENTNAME1     string `json:"entname1"`
+	ENTNAME2     string `json:"entname2"`
+	ENTNAME3     string `json:"entname3"`
+	RUNAME1      string `json:"runame1"`
+	RUNAME2      string `json:"runame2"`
+	RUNAME3      string `json:"runame3"`
+	TRADSTYLE1   string `json:"tradstyle1"`
+	TRADSTYLE2   string `json:"tradstyle2"`
+	TRADSTYLE3   string `json:"tradstyle3"`
+	SELTYPE      string `json:"seltype"`
+	INCLEXCL     string `json:"inclexcl"`
+	CELLNO       int    `json:"cellNo"`
+	FORMTYPE     string `json:"formType"`
+	CURRENCY     string `json:"currency"`
+	SAMPLEUNITID string `json:"sampleUnitRef"`
 }
 
-func processParty(line []byte, sampleSummaryId string, sampleUnitId string, msg *pubsub.Message) error {
+func processParty(line []string, sampleSummaryId string, sampleUnitId string, msg *pubsub.Message) error {
 	logger.Debug("processing party")
 	p := newParty(line, sampleSummaryId, sampleUnitId)
 	p.msg = msg
 	return p.sendToPartyService()
 }
 
-func newParty(line []byte, sampleSummaryId string, sampleUnitId string) *Party {
-	logger.Debug("reading csv line")
-	r := csv.NewReader(bytes.NewReader(line))
-	r.Comma = ':'
-
-	sample, err := r.Read()
-	if err != nil {
-		logger.Fatal("unable to parse sample csv", zap.Error(err))
-	}
-	logger.Debug("read sample", zap.Strings("sample", sample))
-
+func newParty(line []string, sampleSummaryId string, sampleUnitId string) *Party {
 	attr := &Attributes{
-		CHECKLETTER:   setIfNotEmpty(&sample[1]),
-		FROSIC92:      setIfNotEmpty(&sample[2]),
-		RUSIC92:       setIfNotEmpty(&sample[3]),
-		FROSIC2007:    setIfNotEmpty(&sample[4]),
-		RUSIC2007:     setIfNotEmpty(&sample[5]),
-		FROEMPMENT:    convertToInt(sample[6]),
-		FROTOVER:      convertToInt(sample[7]),
-		ENTREF:        setIfNotEmpty(&sample[8]),
-		LEGALSTATUS:   setIfNotEmpty(&sample[9]),
-		NAME:		   "",
-		ENTREPMKR:     setIfNotEmpty(&sample[10]),
-		REGION:        setIfNotEmpty(&sample[11]),
-		BIRTHDATE:     setIfNotEmpty(&sample[12]),
-		ENTNAME1:      setIfNotEmpty(&sample[13]),
-		ENTNAME2:      setIfNotEmpty(&sample[14]),
-		ENTNAME3:      setIfNotEmpty(&sample[15]),
-		RUNAME1:       setIfNotEmpty(&sample[16]),
-		RUNAME2:       setIfNotEmpty(&sample[17]),
-		RUNAME3:       setIfNotEmpty(&sample[18]),
-		TRADSTYLE1:    setIfNotEmpty(&sample[19]),
-		TRADSTYLE2:    setIfNotEmpty(&sample[20]),
-		TRADSTYLE3:    setIfNotEmpty(&sample[21]),
-		SELTYPE:       setIfNotEmpty(&sample[22]),
-		INCLEXCL:      setIfNotEmpty(&sample[23]),
-		CELLNO:        convertToInt(sample[24]),
-		FORMTYPE:      setIfNotEmpty(&sample[25]),
-		CURRENCY:      setIfNotEmpty(&sample[26]),
-		SAMPLEUNITID:  sampleUnitId,
+		CHECKLETTER:  setIfNotEmpty(&line[1]),
+		FROSIC92:     setIfNotEmpty(&line[2]),
+		RUSIC92:      setIfNotEmpty(&line[3]),
+		FROSIC2007:   setIfNotEmpty(&line[4]),
+		RUSIC2007:    setIfNotEmpty(&line[5]),
+		FROEMPMENT:   convertToInt(line[6]),
+		FROTOVER:     convertToInt(line[7]),
+		ENTREF:       setIfNotEmpty(&line[8]),
+		LEGALSTATUS:  setIfNotEmpty(&line[9]),
+		NAME:         "",
+		ENTREPMKR:    setIfNotEmpty(&line[10]),
+		REGION:       setIfNotEmpty(&line[11]),
+		BIRTHDATE:    setIfNotEmpty(&line[12]),
+		ENTNAME1:     setIfNotEmpty(&line[13]),
+		ENTNAME2:     setIfNotEmpty(&line[14]),
+		ENTNAME3:     setIfNotEmpty(&line[15]),
+		RUNAME1:      setIfNotEmpty(&line[16]),
+		RUNAME2:      setIfNotEmpty(&line[17]),
+		RUNAME3:      setIfNotEmpty(&line[18]),
+		TRADSTYLE1:   setIfNotEmpty(&line[19]),
+		TRADSTYLE2:   setIfNotEmpty(&line[20]),
+		TRADSTYLE3:   setIfNotEmpty(&line[21]),
+		SELTYPE:      setIfNotEmpty(&line[22]),
+		INCLEXCL:     setIfNotEmpty(&line[23]),
+		CELLNO:       convertToInt(line[24]),
+		FORMTYPE:     setIfNotEmpty(&line[25]),
+		CURRENCY:     setIfNotEmpty(&line[26]),
+		SAMPLEUNITID: sampleUnitId,
 	}
 	party := &Party{
-		SAMPLEUNITREF: sample[0],
+		SAMPLEUNITREF:   line[0],
 		SAMPLESUMMARYID: sampleSummaryId,
-		SAMPLEUNITTYPE: "B",
-		Attributes: *attr,
+		SAMPLEUNITTYPE:  "B",
+		Attributes:      *attr,
 	}
 	logger.Debug("party created", zap.String("SAMPLEUNITREF", party.SAMPLEUNITREF))
 	return party
@@ -123,7 +111,7 @@ func setIfNotEmpty(value *string) string {
 func convertToInt(value string) int {
 	v, err := strconv.Atoi(value)
 	if err != nil {
-		logger.Error("error converting to int",  zap.Error(err))
+		logger.Error("error converting to int", zap.Error(err))
 		v = 0
 	}
 	return v
@@ -141,9 +129,9 @@ func (p *Party) sendToPartyService() error {
 func (p Party) marshall() ([]byte, error) {
 	//marshall to JSON and send to the sample service as a POST request
 	payload, err := json.Marshal(p)
-	logger.Debug("marshalled sample to json", zap.ByteString("payload", payload))
+	logger.Debug("marshalled party to json", zap.ByteString("payload", payload))
 	if err != nil {
-		logger.Error("unable to marshall sample to json", zap.Error(err))
+		logger.Error("unable to marshall party to json", zap.Error(err))
 		return nil, err
 	}
 	return payload, nil
@@ -153,7 +141,7 @@ func (p Party) getPartyServiceUrl() string {
 	partyServiceBaseUrl := viper.GetString("PARTY_SERVICE_BASE_URL")
 	partyServicePath := "/party-api/v1/parties"
 	partyServiceUrl := partyServiceBaseUrl + partyServicePath
-	logger.Info("using sample service url", zap.String("url", partyServiceUrl))
+	logger.Info("using party service url", zap.String("url", partyServiceUrl))
 	return partyServiceUrl
 }
 
@@ -181,7 +169,7 @@ func (p Party) sendHttpRequest(url string, payload []byte) error {
 		return err
 	}
 	logger.Debug("response received", zap.ByteString("body", body))
-	if resp.StatusCode == http.StatusOK ||  resp.StatusCode == http.StatusCreated  {
+	if resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusCreated {
 		logger.Info("party created", zap.String("sampleUnitRef", p.SAMPLEUNITREF), zap.String("messageId", p.msg.ID))
 		return nil
 	} else if resp.StatusCode == http.StatusConflict {

--- a/party.go
+++ b/party.go
@@ -146,7 +146,6 @@ func (p Party) getPartyServiceUrl() string {
 }
 
 func (p Party) sendHttpRequest(url string, payload []byte) error {
-	//resp, err := http.Post(url, "application/json", bytes.NewReader(payload))
 	username := viper.GetString("SECURITY_USER_NAME")
 	password := viper.GetString("SECURITY_USER_PASSWORD")
 	client := &http.Client{}
@@ -172,12 +171,8 @@ func (p Party) sendHttpRequest(url string, payload []byte) error {
 	if resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusCreated {
 		logger.Info("party created", zap.String("sampleUnitRef", p.SAMPLEUNITREF), zap.String("messageId", p.msg.ID))
 		return nil
-	} else if resp.StatusCode == http.StatusConflict {
-		logger.Warn("attempted to create duplicate sample", zap.Int("status code", resp.StatusCode), zap.String("sampleUnitRef", p.SAMPLEUNITREF), zap.String("messageId", p.msg.ID))
-		// if this sample unit has already been created ack the message to stop it being recreated
-		return nil
 	} else {
-		logger.Error("party not created status", zap.Int("status code", resp.StatusCode), zap.String("sampleUnitRef", p.SAMPLEUNITREF), zap.String("messageId", p.msg.ID))
+		logger.Error("party not created", zap.Int("status code", resp.StatusCode), zap.String("sampleUnitRef", p.SAMPLEUNITREF), zap.String("messageId", p.msg.ID))
 		return errors.New(fmt.Sprintf("sample not created - status code %d", resp.StatusCode))
 	}
 }

--- a/party.go
+++ b/party.go
@@ -16,7 +16,7 @@ import (
 type Party struct {
 	SAMPLEUNITREF string `json:"sampleUnitRef"`
 	SAMPLESUMMARYID string `json:"sampleSummaryId"`
-	SAMPLEUNITTYPE string `json:sampleUnitType`
+	SAMPLEUNITTYPE string `json:"sampleUnitType""`
 	attributes Attributes `json:attributes`
 
 	msg             *pubsub.Message `json:"-"`

--- a/party.go
+++ b/party.go
@@ -181,7 +181,7 @@ func (p Party) sendHttpRequest(url string, payload []byte) error {
 		return err
 	}
 	logger.Debug("response received", zap.ByteString("body", body))
-	if resp.StatusCode == http.StatusCreated {
+	if resp.StatusCode == http.StatusOK ||  resp.StatusCode == http.StatusCreated  {
 		logger.Info("party created", zap.String("sampleUnitRef", p.SAMPLEUNITREF), zap.String("messageId", p.msg.ID))
 		return nil
 	} else if resp.StatusCode == http.StatusConflict {

--- a/party.go
+++ b/party.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"fmt"
 	"errors"
+	"strconv"
 )
 
 type Party struct {
@@ -22,34 +23,34 @@ type Party struct {
 }
 
 type Attributes struct {
-	CHECKLETTER   string `json:"checkletter,omitempty"`
-	FROSIC92      string `json:"frosic92,omitempty"`
-	RUSIC92       string `json:"rusic92,omitempty"`
-	FROSIC2007    string `json:"frosic2007,omitempty"`
-	RUSIC2007     string `json:"rusic2007,omitempty"`
-	FROEMPMENT    string `json:"froempment,omitempty"`
-	FROTOVER      string `json:"frotover,omitempty"`
-	ENTREF        string `json:"entref,omitempty"`
-	LEGALSTATUS   string `json:"legalstatus,omitempty"`
-	NAME		  string `json:"name,omitempty"`
-	ENTREPMKR     string `json:"entrepmkr,omitempty"`
-	REGION        string `json:"region,omitempty"`
-	BIRTHDATE     string `json:"birthdate,omitempty"`
-	ENTNAME1      string `json:"entname1,omitempty"`
-	ENTNAME2      string `json:"entname2,omitempty"`
-	ENTNAME3      string `json:"entname3,omitempty"`
-	RUNAME1       string `json:"runame1,omitempty"`
-	RUNAME2       string `json:"runame2,omitempty"`
-	RUNAME3       string `json:"runame3,omitempty"`
-	TRADSTYLE1    string `json:"tradstyle1,omitempty"`
-	TRADSTYLE2    string `json:"tradstyle2,omitempty"`
-	TRADSTYLE3    string `json:"tradstyle3,omitempty"`
-	SELTYPE       string `json:"seltype,omitempty"`
-	INCLEXCL      string `json:"inclexcl,omitempty"`
-	CELLNO        string `json:"cellNo,omitempty"`
-	FORMTYPE      string `json:"formType,omitempty"`
-	CURRENCY      string `json:"currency,omitempty"`
-	SAMPLEUNITID  string `json:"sampleUnitRef,omitempty"`
+	CHECKLETTER   string `json:"checkletter"`
+	FROSIC92      string `json:"frosic92"`
+	RUSIC92       string `json:"rusic92"`
+	FROSIC2007    string `json:"frosic2007"`
+	RUSIC2007     string `json:"rusic2007"`
+	FROEMPMENT    int `json:"froempment"`
+	FROTOVER      int `json:"frotover"`
+	ENTREF        string `json:"entref"`
+	LEGALSTATUS   string `json:"legalstatus"`
+	NAME		  string `json:"name"`
+	ENTREPMKR     string `json:"entrepmkr"`
+	REGION        string `json:"region"`
+	BIRTHDATE     string `json:"birthdate"`
+	ENTNAME1      string `json:"entname1"`
+	ENTNAME2      string `json:"entname2"`
+	ENTNAME3      string `json:"entname3"`
+	RUNAME1       string `json:"runame1"`
+	RUNAME2       string `json:"runame2"`
+	RUNAME3       string `json:"runame3"`
+	TRADSTYLE1    string `json:"tradstyle1"`
+	TRADSTYLE2    string `json:"tradstyle2"`
+	TRADSTYLE3    string `json:"tradstyle3"`
+	SELTYPE       string `json:"seltype"`
+	INCLEXCL      string `json:"inclexcl"`
+	CELLNO        int `json:"cellNo"`
+	FORMTYPE      string `json:"formType"`
+	CURRENCY      string `json:"currency"`
+	SAMPLEUNITID  string `json:"sampleUnitRef"`
 
 }
 
@@ -77,8 +78,8 @@ func newParty(line []byte, sampleSummaryId string, sampleUnitId string) *Party {
 		RUSIC92:       setIfNotEmpty(&sample[3]),
 		FROSIC2007:    setIfNotEmpty(&sample[4]),
 		RUSIC2007:     setIfNotEmpty(&sample[5]),
-		FROEMPMENT:    setIfNotEmpty(&sample[6]),
-		FROTOVER:      setIfNotEmpty(&sample[7]),
+		FROEMPMENT:    convertToInt(sample[6]),
+		FROTOVER:      convertToInt(sample[7]),
 		ENTREF:        setIfNotEmpty(&sample[8]),
 		LEGALSTATUS:   setIfNotEmpty(&sample[9]),
 		NAME:		   "",
@@ -96,7 +97,7 @@ func newParty(line []byte, sampleSummaryId string, sampleUnitId string) *Party {
 		TRADSTYLE3:    setIfNotEmpty(&sample[21]),
 		SELTYPE:       setIfNotEmpty(&sample[22]),
 		INCLEXCL:      setIfNotEmpty(&sample[23]),
-		CELLNO:        setIfNotEmpty(&sample[24]),
+		CELLNO:        convertToInt(sample[24]),
 		FORMTYPE:      setIfNotEmpty(&sample[25]),
 		CURRENCY:      setIfNotEmpty(&sample[26]),
 		SAMPLEUNITID:  sampleUnitId,
@@ -117,6 +118,15 @@ func setIfNotEmpty(value *string) string {
 	} else {
 		return *value
 	}
+}
+
+func convertToInt(value string) int {
+	v, err := strconv.Atoi(value)
+	if err != nil {
+		logger.Error("error converting to int",  zap.Error(err))
+		v = 0
+	}
+	return v
 }
 
 func (p *Party) sendToPartyService() error {

--- a/party.go
+++ b/party.go
@@ -105,7 +105,7 @@ func newParty(line []byte, sampleSummaryId string, sampleUnitId string) *Party {
 		SAMPLEUNITREF: sample[0],
 		SAMPLESUMMARYID: sampleSummaryId,
 		SAMPLEUNITTYPE: "B",
-		attributes: *attr,
+		Attributes: *attr,
 	}
 	logger.Debug("party created", zap.String("SAMPLEUNITREF", party.SAMPLEUNITREF))
 	return party

--- a/party.go
+++ b/party.go
@@ -73,33 +73,33 @@ func newParty(line []byte, sampleSummaryId string, sampleUnitId string) *Party {
 	logger.Debug("read sample", zap.Strings("sample", sample))
 
 	attr := &Attributes{
-		CHECKLETTER:   sample[1],
-		FROSIC92:      sample[2],
-		RUSIC92:       sample[3],
-		FROSIC2007:    sample[4],
-		RUSIC2007:     sample[5],
-		FROEMPMENT:    sample[6],
-		FROTOVER:      sample[7],
-		ENTREF:        sample[8],
-		LEGALSTATUS:   sample[9],
+		CHECKLETTER:   setIfNotEmpty(&sample[1]),
+		FROSIC92:      setIfNotEmpty(&sample[2]),
+		RUSIC92:       setIfNotEmpty(&sample[3]),
+		FROSIC2007:    setIfNotEmpty(&sample[4]),
+		RUSIC2007:     setIfNotEmpty(&sample[5]),
+		FROEMPMENT:    setIfNotEmpty(&sample[6]),
+		FROTOVER:      setIfNotEmpty(&sample[7]),
+		ENTREF:        setIfNotEmpty(&sample[8]),
+		LEGALSTATUS:   setIfNotEmpty(&sample[9]),
 		NAME:		   "",
-		ENTREPMKR:     sample[10],
-		REGION:        sample[11],
-		BIRTHDATE:     sample[12],
-		ENTNAME1:      sample[13],
-		ENTNAME2:      sample[14],
-		ENTNAME3:      sample[15],
-		RUNAME1:       sample[16],
-		RUNAME2:       sample[17],
-		RUNAME3:       sample[18],
-		TRADSTYLE1:    sample[19],
-		TRADSTYLE2:    sample[20],
-		TRADSTYLE3:    sample[21],
-		SELTYPE:       sample[22],
-		INCLEXCL:      sample[23],
-		CELLNO:        sample[24],
-		FORMTYPE:      sample[25],
-		CURRENCY:      sample[26],
+		ENTREPMKR:     setIfNotEmpty(&sample[10]),
+		REGION:        setIfNotEmpty(&sample[11]),
+		BIRTHDATE:     setIfNotEmpty(&sample[12]),
+		ENTNAME1:      setIfNotEmpty(&sample[13]),
+		ENTNAME2:      setIfNotEmpty(&sample[14]),
+		ENTNAME3:      setIfNotEmpty(&sample[15]),
+		RUNAME1:       setIfNotEmpty(&sample[16]),
+		RUNAME2:       setIfNotEmpty(&sample[17]),
+		RUNAME3:       setIfNotEmpty(&sample[18]),
+		TRADSTYLE1:    setIfNotEmpty(&sample[19]),
+		TRADSTYLE2:    setIfNotEmpty(&sample[20]),
+		TRADSTYLE3:    setIfNotEmpty(&sample[21]),
+		SELTYPE:       setIfNotEmpty(&sample[22]),
+		INCLEXCL:      setIfNotEmpty(&sample[23]),
+		CELLNO:        setIfNotEmpty(&sample[24]),
+		FORMTYPE:      setIfNotEmpty(&sample[25]),
+		CURRENCY:      setIfNotEmpty(&sample[26]),
 		SAMPLEUNITID:  sampleUnitId,
 	}
 	party := &Party{
@@ -111,6 +111,14 @@ func newParty(line []byte, sampleSummaryId string, sampleUnitId string) *Party {
 	}
 	logger.Debug("party created", zap.String("SAMPLEUNITREF", party.SAMPLEUNITREF))
 	return party
+}
+
+func setIfNotEmpty(value *string) string {
+	if value == nil {
+		return ""
+	} else {
+		return *value
+	}
 }
 
 func (p *Party) sendToPartyService() error {

--- a/party.go
+++ b/party.go
@@ -17,7 +17,7 @@ type Party struct {
 	SAMPLEUNITREF string `json:"sampleUnitRef"`
 	SAMPLESUMMARYID string `json:"sampleSummaryId"`
 	SAMPLEUNITTYPE string `json:"sampleUnitType""`
-	attributes *Attributes `json:attributes`
+	attributes *Attributes `json:"attributes""`
 	msg             *pubsub.Message `json:"-"`
 }
 

--- a/party.go
+++ b/party.go
@@ -49,7 +49,7 @@ type Attributes struct {
 	CELLNO       int    `json:"cellNo"`
 	FORMTYPE     string `json:"formType"`
 	CURRENCY     string `json:"currency"`
-	SAMPLEUNITID string `json:"sampleUnitRef"`
+	SAMPLEUNITID string `json:"sampleUnitId"`
 }
 
 func processParty(line []string, sampleSummaryId string, sampleUnitId string, msg *pubsub.Message) error {

--- a/party.go
+++ b/party.go
@@ -105,6 +105,7 @@ func newParty(line []byte, sampleSummaryId string, sampleUnitId string) *Party {
 	party := &Party{
 		SAMPLEUNITREF: sample[0],
 		SAMPLESUMMARYID: sampleSummaryId,
+		SAMPLEUNITTYPE: "B",
 		attributes: *attr,
 
 	}

--- a/party.go
+++ b/party.go
@@ -23,34 +23,34 @@ type Party struct {
 }
 
 type Attributes struct {
-	CHECKLETTER   string `json:"checkletter"`
-	FROSIC92      string `json:"frosic92"`
-	RUSIC92       string `json:"rusic92"`
-	FROSIC2007    string `json:"frosic2007"`
-	RUSIC2007     string `json:"rusic2007"`
-	FROEMPMENT    string `json:"froempment"`
-	FROTOVER      string `json:"frotover"`
-	ENTREF        string `json:"entref"`
-	LEGALSTATUS   string `json:"legalstatus"`
-	NAME		  string `json:"name"`
-	ENTREPMKR     string `json:"entrepmkr"`
-	REGION        string `json:"region"`
-	BIRTHDATE     string `json:"birthdate"`
-	ENTNAME1      string `json:"entname1"`
-	ENTNAME2      string `json:"entname2"`
-	ENTNAME3      string `json:"entname3"`
-	RUNAME1       string `json:"runame1"`
-	RUNAME2       string `json:"runame2"`
-	RUNAME3       string `json:"runame3"`
-	TRADSTYLE1    string `json:"tradstyle1"`
-	TRADSTYLE2    string `json:"tradstyle2"`
-	TRADSTYLE3    string `json:"tradstyle3"`
-	SELTYPE       string `json:"seltype"`
-	INCLEXCL      string `json:"inclexcl"`
-	CELLNO        string `json:"cellNo"`
-	FORMTYPE      string `json:"formType"`
-	CURRENCY      string `json:"currency"`
-	SAMPLEUNITID  string `json:"sampleUnitRef"`
+	CHECKLETTER   string `json:"checkletter,omitempty"`
+	FROSIC92      string `json:"frosic92,omitempty"`
+	RUSIC92       string `json:"rusic92,omitempty"`
+	FROSIC2007    string `json:"frosic2007,omitempty"`
+	RUSIC2007     string `json:"rusic2007,omitempty"`
+	FROEMPMENT    string `json:"froempment,omitempty"`
+	FROTOVER      string `json:"frotover,omitempty"`
+	ENTREF        string `json:"entref,omitempty"`
+	LEGALSTATUS   string `json:"legalstatus,omitempty"`
+	NAME		  string `json:"name,omitempty"`
+	ENTREPMKR     string `json:"entrepmkr,omitempty"`
+	REGION        string `json:"region,omitempty"`
+	BIRTHDATE     string `json:"birthdate,omitempty"`
+	ENTNAME1      string `json:"entname1,omitempty"`
+	ENTNAME2      string `json:"entname2,omitempty"`
+	ENTNAME3      string `json:"entname3,omitempty"`
+	RUNAME1       string `json:"runame1,omitempty"`
+	RUNAME2       string `json:"runame2,omitempty"`
+	RUNAME3       string `json:"runame3,omitempty"`
+	TRADSTYLE1    string `json:"tradstyle1,omitempty"`
+	TRADSTYLE2    string `json:"tradstyle2,omitempty"`
+	TRADSTYLE3    string `json:"tradstyle3,omitempty"`
+	SELTYPE       string `json:"seltype,omitempty"`
+	INCLEXCL      string `json:"inclexcl,omitempty"`
+	CELLNO        string `json:"cellNo,omitempty"`
+	FORMTYPE      string `json:"formType,omitempty"`
+	CURRENCY      string `json:"currency,omitempty"`
+	SAMPLEUNITID  string `json:"sampleUnitRef,omitempty"`
 
 }
 
@@ -82,7 +82,7 @@ func newParty(line []byte, sampleSummaryId string, sampleUnitId string) *Party {
 		FROTOVER:      sample[7],
 		ENTREF:        sample[8],
 		LEGALSTATUS:   sample[9],
-		NAME:		   "None",
+		NAME:		   "",
 		ENTREPMKR:     sample[10],
 		REGION:        sample[11],
 		BIRTHDATE:     sample[12],

--- a/party.go
+++ b/party.go
@@ -17,7 +17,7 @@ type Party struct {
 	SAMPLEUNITREF string `json:"sampleUnitRef"`
 	SAMPLESUMMARYID string `json:"sampleSummaryId"`
 	SAMPLEUNITTYPE string `json:"sampleUnitType""`
-	attributes *Attributes `json:"attributes""`
+	Attributes 		Attributes `json:"attributes""`
 	msg             *pubsub.Message `json:"-"`
 }
 
@@ -105,7 +105,7 @@ func newParty(line []byte, sampleSummaryId string, sampleUnitId string) *Party {
 		SAMPLEUNITREF: sample[0],
 		SAMPLESUMMARYID: sampleSummaryId,
 		SAMPLEUNITTYPE: "B",
-		attributes: attr,
+		attributes: *attr,
 	}
 	logger.Debug("party created", zap.String("SAMPLEUNITREF", party.SAMPLEUNITREF))
 	return party

--- a/party.go
+++ b/party.go
@@ -17,8 +17,7 @@ type Party struct {
 	SAMPLEUNITREF string `json:"sampleUnitRef"`
 	SAMPLESUMMARYID string `json:"sampleSummaryId"`
 	SAMPLEUNITTYPE string `json:"sampleUnitType""`
-	attributes Attributes `json:attributes`
-
+	attributes *Attributes `json:attributes`
 	msg             *pubsub.Message `json:"-"`
 }
 
@@ -106,8 +105,7 @@ func newParty(line []byte, sampleSummaryId string, sampleUnitId string) *Party {
 		SAMPLEUNITREF: sample[0],
 		SAMPLESUMMARYID: sampleSummaryId,
 		SAMPLEUNITTYPE: "B",
-		attributes: *attr,
-
+		attributes: attr,
 	}
 	logger.Debug("party created", zap.String("SAMPLEUNITREF", party.SAMPLEUNITREF))
 	return party

--- a/party_test.go
+++ b/party_test.go
@@ -1,0 +1,143 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"testing"
+	"cloud.google.com/go/pubsub"
+	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
+	"net/http"
+	"net/http/httptest"
+)
+
+func TestPartySuccess(t *testing.T) {
+	assert := assert.New(t)
+	ts := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		w.Write([]byte("OK"))
+	}))
+	ts.Start()
+	defer ts.Close()
+
+	fmt.Printf("Setting party service base url %v", ts.URL)
+	viper.Set("PARTY_SERVICE_BASE_URL", ts.URL)
+
+	line := []byte("13110000001:::::::::::WW:::::OFFICE FOR NATIONAL STATISTICS:::::::::0001:")
+
+	msg := &pubsub.Message{
+		Data: []byte(line),
+		Attributes: map[string]string{
+			"sample_summary_id": "test",
+		},
+		ID: "1",
+	}
+	sample := readSampleLine(line)
+	err := processParty(sample, "test", "test", msg)
+	assert.Nil(err, "error should be nil")
+}
+
+
+func TestPartyError(t *testing.T) {
+	assert := assert.New(t)
+	ts := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte("ERROR"))
+	}))
+	ts.Start()
+	defer ts.Close()
+
+	fmt.Printf("Setting party service base url %v", ts.URL)
+	viper.Set("PARTY_SERVICE_BASE_URL", ts.URL)
+
+	line := []byte("13110000001:::::::::::WW:::::OFFICE FOR NATIONAL STATISTICS:::::::::0001:")
+
+	msg := &pubsub.Message{
+		Data: []byte(line),
+		Attributes: map[string]string{
+			"sample_summary_id": "test",
+		},
+		ID: "1",
+	}
+	sample := readSampleLine(line)
+	err := processParty(sample, "test", "test", msg)
+	assert.NotNil(err, "error should be nil")
+}
+
+func TestPartyServerURL(t *testing.T) {
+	p := &Party{}
+
+	assert := assert.New(t)
+	// set env variables and check url is correct
+	viper.Set("PARTY_SERVICE_BASE_URL", "https://127.0.0.1")
+
+	assert.Equal("https://127.0.0.1/party-api/v1/parties", p.getPartyServiceUrl())
+}
+
+
+func TestPartySendHttpRequest(t *testing.T) {
+	p := &Party{}
+	p.msg = &pubsub.Message{
+		Data: []byte(line),
+		Attributes: map[string]string{
+			"sample_summary_id": "test",
+		},
+		ID: "1",
+	}
+	assert := assert.New(t)
+	payload := []byte("TEST")
+
+	ts := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := ioutil.ReadAll(r.Body)
+		assert.Nil(err)
+		assert.Equal(payload, body)
+		w.WriteHeader(http.StatusCreated)
+		w.Write([]byte("OK"))
+	}))
+	ts.Start()
+	defer ts.Close()
+	err := p.sendHttpRequest(ts.URL, payload)
+	assert.Nil(err, "error should be nil")
+}
+
+func TestPartySendHttpRequestBadUrl(t *testing.T) {
+	p := &Party{}
+	p.msg = &pubsub.Message{
+		Data: []byte(line),
+		Attributes: map[string]string{
+			"sample_summary_id": "test",
+		},
+		ID: "1",
+	}
+
+	assert := assert.New(t)
+	payload := []byte("TEST")
+	err := p.sendHttpRequest("http://localhost", payload)
+	assert.NotNil(err, "error should be nil")
+}
+
+func TestPartySendHttpRequestWrongStatus(t *testing.T) {
+	p := &Party{}
+	p.msg = &pubsub.Message{
+		Data: []byte(line),
+		Attributes: map[string]string{
+			"sample_summary_id": "test",
+		},
+		ID: "1",
+	}
+
+	assert := assert.New(t)
+	payload := []byte("TEST")
+
+	ts := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := ioutil.ReadAll(r.Body)
+		assert.Nil(err)
+		assert.Equal(payload, body)
+		w.WriteHeader(http.StatusAccepted)
+		w.Write([]byte("OK"))
+	}))
+	ts.Start()
+	defer ts.Close()
+	err := p.sendHttpRequest(ts.URL, payload)
+	assert.NotNil(err, "error should be nil")
+}

--- a/sample.go
+++ b/sample.go
@@ -157,7 +157,7 @@ func (s Sample) sendHttpRequest(url string, payload []byte) (string, error) {
 }
 
 func (s Sample) getSampleUnitID() (string, error) {
-	logger.Debug("attempting to retrieve sample unit ", zap.String("sampleUnitRef", s.SAMPLEUNITREF), zap.String("messageId", s.msg.ID))
+	logger.Debug("attempting to retrieve sample unit", zap.String("sampleUnitRef", s.SAMPLEUNITREF), zap.String("messageId", s.msg.ID))
 	sampleServiceBaseUrl := viper.GetString("SAMPLE_SERVICE_BASE_URL")
 	sampleServiceGetPath := fmt.Sprintf("/samples/%s/sampleunits/%s", s.sampleSummaryId, s.SAMPLEUNITREF)
 	sampleServiceGetUrl := sampleServiceBaseUrl + sampleServiceGetPath
@@ -181,6 +181,7 @@ func (s Sample) getSampleUnitID() (string, error) {
 			logger.Error("error decoding JSON response", zap.Error(err))
 		}
 		sampleUnitId, ok := data["id"].(string)
+		logger.Debug("retrieved sample unit id", zap.String("sampleUnitId", sampleUnitId), zap.String("sampleUnitRef", s.SAMPLEUNITREF), zap.String("messageId", s.msg.ID))
 		if !ok {
 			logger.Error("missing sample unit id", zap.String("sampleUnitRef", s.SAMPLEUNITREF), zap.String("messageId", s.msg.ID))
 			return "", errors.New("unable to find sample unit")

--- a/sample_test.go
+++ b/sample_test.go
@@ -34,7 +34,7 @@ func TestSampleSuccess(t *testing.T) {
 		ID: "1",
 	}
 
-	err := processSample(sample, "test", msg)
+	_, err := processSample(sample, "test", msg)
 	assert.Nil(err, "error should be nil")
 }
 
@@ -60,7 +60,7 @@ func TestSampleError(t *testing.T) {
 		ID: "1",
 	}
 
-	err := processSample(sample, "test", msg)
+	_, err := processSample(sample, "test", msg)
 	assert.NotNil(t, err, "error should not be nil")
 }
 
@@ -102,7 +102,7 @@ func TestSendHttpRequest(t *testing.T) {
 	}))
 	ts.Start()
 	defer ts.Close()
-	err := s.sendHttpRequest(ts.URL, payload)
+	_, err := s.sendHttpRequest(ts.URL, payload)
 	assert.Nil(err, "error should be nil")
 }
 
@@ -117,7 +117,7 @@ func TestSendHttpRequestBadUrl(t *testing.T) {
 	}
 	assert := assert.New(t)
 	payload := []byte("TEST")
-	err := s.sendHttpRequest("http://localhost", payload)
+	_, err := s.sendHttpRequest("http://localhost", payload)
 	assert.NotNil(err, "error should be nil")
 }
 
@@ -142,7 +142,7 @@ func TestSendHttpRequestWrongStatus(t *testing.T) {
 	}))
 	ts.Start()
 	defer ts.Close()
-	err := s.sendHttpRequest(ts.URL, payload)
+	_, err := s.sendHttpRequest(ts.URL, payload)
 	assert.NotNil(err, "error should be nil")
 }
 
@@ -158,7 +158,7 @@ func TestSendSampleSuccess(t *testing.T) {
 	viper.Set("SAMPLE_SERVICE_BASE_URL", ts.URL)
 
 	s := createSample()
-	err := s.sendToSampleService()
+	_, err := s.sendToSampleService()
 	assert.Nil(err, "error should be nil")
 }
 

--- a/sample_test.go
+++ b/sample_test.go
@@ -16,7 +16,7 @@ func TestSampleSuccess(t *testing.T) {
 	assert := assert.New(t)
 	ts := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusCreated)
-		w.Write([]byte("OK"))
+		w.Write([]byte("{\"id\":\"1111\"}"))
 	}))
 	ts.Start()
 	defer ts.Close()
@@ -99,7 +99,7 @@ func TestSendHttpRequest(t *testing.T) {
 		assert.Nil(err)
 		assert.Equal(payload, body)
 		w.WriteHeader(http.StatusCreated)
-		w.Write([]byte("OK"))
+		w.Write([]byte("{\"id\":\"1111\"}"))
 	}))
 	ts.Start()
 	defer ts.Close()
@@ -139,7 +139,7 @@ func TestSendHttpRequestWrongStatus(t *testing.T) {
 		assert.Nil(err)
 		assert.Equal(payload, body)
 		w.WriteHeader(http.StatusAccepted)
-		w.Write([]byte("OK"))
+		w.Write([]byte("{\"id\":\"1111\"}"))
 	}))
 	ts.Start()
 	defer ts.Close()
@@ -151,7 +151,7 @@ func TestSendSampleSuccess(t *testing.T) {
 	assert := assert.New(t)
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusCreated)
-		w.Write([]byte("OK"))
+		w.Write([]byte("{\"id\":\"1111\"}"))
 	}))
 	defer ts.Close()
 

--- a/sample_test.go
+++ b/sample_test.go
@@ -24,16 +24,16 @@ func TestSampleSuccess(t *testing.T) {
 	fmt.Printf("Setting sample service base url %v", ts.URL)
 	viper.Set("SAMPLE_SERVICE_BASE_URL", ts.URL)
 
-	sample := []byte("13110000001:::::::::::WW:::::OFFICE FOR NATIONAL STATISTICS:::::::::0001:")
+	line := []byte("13110000001:::::::::::WW:::::OFFICE FOR NATIONAL STATISTICS:::::::::0001:")
 
 	msg := &pubsub.Message{
-		Data: []byte(sample),
+		Data: []byte(line),
 		Attributes: map[string]string{
 			"sample_summary_id": "test",
 		},
 		ID: "1",
 	}
-
+	sample := readSampleLine(line)
 	_, err := processSample(sample, "test", msg)
 	assert.Nil(err, "error should be nil")
 }
@@ -50,16 +50,17 @@ func TestSampleError(t *testing.T) {
 	fmt.Printf("Setting sample service base url %v", ts.URL)
 	viper.Set("SAMPLE_SERVICE_BASE_URL", ts.URL)
 
-	sample := []byte("13110000001:::::::::::WW:::::OFFICE FOR NATIONAL STATISTICS:::::::::0001:")
+	line := []byte("13110000001:::::::::::WW:::::OFFICE FOR NATIONAL STATISTICS:::::::::0001:")
 
 	msg := &pubsub.Message{
-		Data: []byte(sample),
+		Data: []byte(line),
 		Attributes: map[string]string{
 			"sample_summary_id": "test",
 		},
 		ID: "1",
 	}
 
+	sample := readSampleLine(line)
 	_, err := processSample(sample, "test", msg)
 	assert.NotNil(t, err, "error should not be nil")
 }
@@ -67,7 +68,7 @@ func TestSampleError(t *testing.T) {
 func TestSampleServerURL(t *testing.T) {
 	s := &Sample{}
 	s.msg = &pubsub.Message{
-		Data: []byte(sample),
+		Data: []byte(line),
 		Attributes: map[string]string{
 			"sample_summary_id": "test",
 		},
@@ -84,7 +85,7 @@ func TestSampleServerURL(t *testing.T) {
 func TestSendHttpRequest(t *testing.T) {
 	s := &Sample{}
 	s.msg = &pubsub.Message{
-		Data: []byte(sample),
+		Data: []byte(line),
 		Attributes: map[string]string{
 			"sample_summary_id": "test",
 		},
@@ -109,7 +110,7 @@ func TestSendHttpRequest(t *testing.T) {
 func TestSendHttpRequestBadUrl(t *testing.T) {
 	s := &Sample{}
 	s.msg = &pubsub.Message{
-		Data: []byte(sample),
+		Data: []byte(line),
 		Attributes: map[string]string{
 			"sample_summary_id": "test",
 		},
@@ -124,7 +125,7 @@ func TestSendHttpRequestBadUrl(t *testing.T) {
 func TestSendHttpRequestWrongStatus(t *testing.T) {
 	s := &Sample{}
 	s.msg = &pubsub.Message{
-		Data: []byte(sample),
+		Data: []byte(line),
 		Attributes: map[string]string{
 			"sample_summary_id": "test",
 		},
@@ -241,7 +242,7 @@ func createSample() *Sample {
 	s.TRADSTYLE2 = "trad2"
 	s.TRADSTYLE3 = "trad3"
 	s.msg = &pubsub.Message{
-		Data: []byte(sample),
+		Data: []byte(line),
 		Attributes: map[string]string{
 			"sample_summary_id": "test",
 		},

--- a/sample_test.go
+++ b/sample_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+
 func TestSampleSuccess(t *testing.T) {
 	assert := assert.New(t)
 	ts := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -210,6 +211,42 @@ func TestMarshallEmptyStruct(t *testing.T) {
 	assert.Nil(err)
 	emptySample := createEmptySample()
 	assert.Equal(emptySample, string(sample))
+}
+
+func TestGetSampleUnit(t *testing.T) {
+	configureLogging()
+	assert := assert.New(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("{\"id\":\"1111\"}"))
+	}))
+	defer ts.Close()
+
+	fmt.Printf("Setting sample service base url %v\n", ts.URL)
+	viper.Set("SAMPLE_SERVICE_BASE_URL", ts.URL)
+
+	s := createSample()
+	id, err := s.getSampleUnitID()
+	assert.Nil(err, "error should be nil")
+	assert.Equal("1111", id)
+}
+
+func TestGetSampleUnitErrorResponse(t *testing.T) {
+	configureLogging()
+	assert := assert.New(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer ts.Close()
+
+	fmt.Printf("Setting sample service base url %v\n", ts.URL)
+	viper.Set("SAMPLE_SERVICE_BASE_URL", ts.URL)
+
+	s := createSample()
+	_, err := s.getSampleUnitID()
+	assert.NotNil(err, "error should be not nil")
 }
 
 func createSample() *Sample {


### PR DESCRIPTION
# What and why?
When parsing the sample file, csv-worker will now create the party entries as well as the sample entries. This will decouple sample service from party service.

# How to test?
Deploy to an environment along with https://github.com/ONSdigital/rm-sample-service/pull/177 and run acceptance test

# Trello
https://trello.com/c/y8asNsc2/698-s36-ce-sample-service-calling-party-via-csv-worker
