### PR TITLE
Deal with 409 responses from party service

### DIFF
--- a/_infra/helm/csv-worker/Chart.yaml
+++ b/_infra/helm/csv-worker/Chart.yaml
@@ -18,4 +18,4 @@ version: 1.0.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 1.0.29
+appVersion: 1.0.30

--- a/party.go
+++ b/party.go
@@ -171,7 +171,10 @@ func (p Party) sendHttpRequest(url string, payload []byte) error {
 	if resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusCreated {
 		logger.Info("party created", zap.String("sampleUnitRef", p.SAMPLEUNITREF), zap.String("messageId", p.msg.ID))
 		return nil
-	} else {
+	} else if resp.StatusCode == http.StatusConflict {
+		logger.Warn("party already exists", zap.String("sampleUnitRef", p.SAMPLEUNITREF), zap.String("messageId", p.msg.ID))
+		return nil
+	}  else {
 		logger.Error("party not created", zap.Int("status code", resp.StatusCode), zap.String("sampleUnitRef", p.SAMPLEUNITREF), zap.String("messageId", p.msg.ID))
 		return errors.New(fmt.Sprintf("sample not created - status code %d", resp.StatusCode))
 	}

--- a/party_test.go
+++ b/party_test.go
@@ -37,6 +37,32 @@ func TestPartySuccess(t *testing.T) {
 	assert.Nil(err, "error should be nil")
 }
 
+func TestPartyConflict(t *testing.T) {
+	assert := assert.New(t)
+	ts := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusConflict)
+		w.Write([]byte("OK"))
+	}))
+	ts.Start()
+	defer ts.Close()
+
+	fmt.Printf("Setting party service base url %v", ts.URL)
+	viper.Set("PARTY_SERVICE_BASE_URL", ts.URL)
+
+	line := []byte("13110000001:::::::::::WW:::::OFFICE FOR NATIONAL STATISTICS:::::::::0001:")
+
+	msg := &pubsub.Message{
+		Data: []byte(line),
+		Attributes: map[string]string{
+			"sample_summary_id": "test",
+		},
+		ID: "1",
+	}
+	sample := readSampleLine(line)
+	err := processParty(sample, "test", "test", msg)
+	assert.Nil(err, "error should be nil")
+}
+
 
 func TestPartyError(t *testing.T) {
 	assert := assert.New(t)


### PR DESCRIPTION
# What and why?
If party returns a 409 conflict then ignore it as the party already exists

# How to test?
Run acceptance tests

# Trello
https://trello.com/c/y8asNsc2/698-s36-ce-sample-service-calling-party-via-csv-worker