### PR TITLE
have duplicate sample units throw an error

### DIFF
--- a/_infra/helm/csv-worker/Chart.yaml
+++ b/_infra/helm/csv-worker/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.0.36
+version: 1.0.37
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 1.0.36
+appVersion: 1.0.37

--- a/sample.go
+++ b/sample.go
@@ -156,9 +156,8 @@ func (s Sample) sendHttpRequest(url string, payload []byte) (string, error) {
 		}
 		return sampleUnitId, nil
 	} else if resp.StatusCode == http.StatusConflict {
-		logger.Warn("attempted to create duplicate sample", zap.Int("status code", resp.StatusCode), zap.String("sampleUnitRef", s.SAMPLEUNITREF), zap.String("messageId", s.msg.ID))
-		// if this sample unit has already been created attempt to retrieve the sample unit id
-		return s.getSampleUnitID()
+		logger.Error("duplicate sample unit detected", zap.Int("status code", resp.StatusCode), zap.String("sampleUnitRef", s.SAMPLEUNITREF), zap.String("messageId", s.msg.ID))
+		return "", errors.New(fmt.Sprintf("Sample file has duplicate sample unit"))
 	} else {
 		logger.Error("sample not created status", zap.Int("status code", resp.StatusCode), zap.String("sampleUnitRef", s.SAMPLEUNITREF), zap.String("messageId", s.msg.ID))
 		return "", errors.New(fmt.Sprintf("sample not created - status code %d", resp.StatusCode))


### PR DESCRIPTION
# What and why?
This PR is an attempt at fixing a bug where r-ops hangs when attempting to load a sample file with a duplicated sample unit. The code has changed so that an error message box appears on the page to indicate that there's a problem with the file.

# How to test?
* Create a sample file that has a duplicate sample unit ref.
* Deploy this PR to your environment and run acceptance tests.
* Create a collection exercise and attach the aforementioned sample file to the CE.
* Keep refreshing the page to check the sample file load process. At first, it will look like it's hanging, but after a while, it will eventually display an "error loading sample" box on the page.
* Check the logs for the sample service pod. There should be some stuff about the sample summary getting set to failed (which didn't happen before). Also, check the logs for csv-worker and look for a message about a duplicate sample unit being detected.

# Trello
[Card](https://trello.com/c/upvtJmqp)
