### PR TITLE
csv-worker gar migration

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @ONSdigital/sdc-rmras

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,9 +10,10 @@ on:
 
 env:
   IMAGE: csv-worker
-  REGISTRY_HOSTNAME: eu.gcr.io
-  HOST: ${{ secrets.GOOGLE_PROJECT_ID }}
-  RELEASE_HOST: ${{ secrets.RELEASE_PROJECT_ID }}
+  REGISTRY_HOSTNAME: europe-west2-docker.pkg.dev
+  SPINNAKER_GOOGLE_PROJECT_ID: ${{ secrets.SPINNAKER_GOOGLE_PROJECT_ID }}
+  GAR_REPOSITORY: images
+  GAR_GOOGLE_PROJECT_ID: ${{ secrets.GAR_GOOGLE_PROJECT_ID }}
   CHART_DIRECTORY: _infra/helm/csv-worker
   SPINNAKER_TOPIC: ${{ secrets.SPINNAKER_TOPIC }}
   ARTIFACT_BUCKET: ${{ secrets.ARTIFACT_BUCKET }}
@@ -39,6 +40,7 @@ jobs:
         uses: google-github-actions/setup-gcloud@v2
       - run: |
           gcloud auth configure-docker
+          gcloud auth configure-docker "$REGISTRY_HOSTNAME"
       - name: pr docker tag
         if: github.ref != 'refs/heads/main'
         id: tag
@@ -50,11 +52,11 @@ jobs:
       - name: Build Docker Image
         if: github.ref != 'refs/heads/main'
         run: |
-          docker build -t "$REGISTRY_HOSTNAME"/"$HOST"/"$IMAGE":${{ env.pr_number }} .
+          docker build -t "$REGISTRY_HOSTNAME"/"$GAR_GOOGLE_PROJECT_ID"/"$GAR_REPOSITORY"/"$IMAGE":${{ env.pr_number }} .
       - name: Push dev image
         if: github.ref != 'refs/heads/main'
         run: |
-          docker push "$REGISTRY_HOSTNAME"/"$HOST"/"$IMAGE":${{ env.pr_number }}
+          docker push "$REGISTRY_HOSTNAME"/"$GAR_GOOGLE_PROJECT_ID"/"$GAR_REPOSITORY"/"$IMAGE":${{ env.pr_number }}
       - name: template helm
         run: |
           helm template $CHART_DIRECTORY
@@ -139,12 +141,12 @@ jobs:
       - name: Build Release Image
         if: github.ref == 'refs/heads/main'
         run: |
-          docker build -t "$REGISTRY_HOSTNAME"/"$RELEASE_HOST"/"$IMAGE":latest -t "$REGISTRY_HOSTNAME"/"$RELEASE_HOST"/"$IMAGE":${{ env.version }} .
+          docker build -t "$REGISTRY_HOSTNAME"/"$GAR_GOOGLE_PROJECT_ID"/"$GAR_REPOSITORY"/"$IMAGE":latest -t "$REGISTRY_HOSTNAME"/"GAR_GOOGLE_PROJECT_ID"/"$GAR_REPOSITORY"/"$IMAGE":${{ env.version }} .
       - name: Push Release image
         if: github.ref == 'refs/heads/main'
         run: |
-          docker push "$REGISTRY_HOSTNAME"/"$RELEASE_HOST"/"$IMAGE":${{ env.version }}
-          docker push "$REGISTRY_HOSTNAME"/"$RELEASE_HOST"/"$IMAGE":latest
+          docker push "$REGISTRY_HOSTNAME"/"$GAR_GOOGLE_PROJECT_ID"/"$GAR_REPOSITORY"/"$IMAGE":${{ env.version }}
+          docker push "$REGISTRY_HOSTNAME"/"$GAR_GOOGLE_PROJECT_ID"/"$GAR_REPOSITORY"/"$IMAGE":latest
 
       - name: Publish Charts
         if: github.ref == 'refs/heads/main'
@@ -161,6 +163,6 @@ jobs:
       - name: CD hook
         if: github.ref == 'refs/heads/main'
         run: |
-          gcloud pubsub topics publish $SPINNAKER_TOPIC --project $HOST \
+          gcloud pubsub topics publish $SPINNAKER_TOPIC --project $SPINNAKER_GOOGLE_PROJECT_ID \
           --message "{ \"kind\": \"storage#object\", \"name\": \"$IMAGE/$IMAGE-${{ env.HELM_VERSION }}.tgz\", \"bucket\": \"$ARTIFACT_BUCKET\" }" \
           --attribute cd="actions"

--- a/_infra/helm/csv-worker/Chart.yaml
+++ b/_infra/helm/csv-worker/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.0.44
+version: 1.0.45
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 1.0.44
+appVersion: 1.0.45

--- a/_infra/helm/csv-worker/values.yaml
+++ b/_infra/helm/csv-worker/values.yaml
@@ -1,8 +1,8 @@
 env: sandbox
 
 image:
-  devRepo: eu.gcr.io/ons-rasrmbs-management
-  name: eu.gcr.io/ons-rasrmbs-management
+  devRepo: europe-west2-docker.pkg.dev/ons-ci-rmrasbs/images
+  name: europe-west2-docker.pkg.dev/ons-ci-rmrasbs/images
   tag: latest
   pullPolicy: Always
 


### PR DESCRIPTION
# What and why?
GAR migration for CSV-worker.

# How to test?
Deploy this to your environment, setting configBranch to `ras-1455-csv-worker-gar-migration`. The deployment will hang until you replace the image in the YAML with `europe-west2-docker.pkg.dev/ons-ci-rmrasbs/images/csv-worker:pr-49`.

Use helm commands to delete the deployment, then redeploy the service in your environment. Note that when doing so, you'll need to pass in values for the topic and subscription, since there seems to be an issue with passing in values via Golang. To do this, add ` --set-string gcp.topic="sample-file-(your namespace)" \ --set-string gcp.subscription="sample-file-(your namespace)" \` to the helm upgrade command.

# Jira
[Card](https://jira.ons.gov.uk/browse/RAS-1455)
