### PR TITLE
RAS-1828 More gracefully handle csv-worker getting an error from party

### DIFF
--- a/_infra/helm/csv-worker/Chart.yaml
+++ b/_infra/helm/csv-worker/Chart.yaml
@@ -14,8 +14,8 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.0.51
+version: 1.0.52
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.
-appVersion: 1.0.51
+appVersion: 1.0.52

--- a/main.go
+++ b/main.go
@@ -75,14 +75,18 @@ func (cw CSVWorker) subscribe(ctx context.Context, client *pubsub.Client) {
 			} else {
 				sampleUnitId, err := processSample(line, sampleSummaryId, msg)
 				if err != nil {
-					logger.Error("error processing sample - nacking message", zap.Error(err))
+					logger.Warn("error processing sample - nacking message",
+						zap.Error(err),
+						zap.String("sampleUnitId", sampleUnitId))
 					//after x number of nacks message will be DLQ
 					msg.Nack()
 				} else {
 					//now the sample has been created, lets create the associated party
 					err := processParty(line, sampleSummaryId, sampleUnitId, msg)
 					if err != nil {
-						logger.Error("error processing party - nacking message", zap.Error(err))
+						logger.Warn("error processing party - nacking message",
+							zap.Error(err),
+							zap.String("sampleUnitId", sampleUnitId))
 						//after x number of nacks message will be DLQ
 						msg.Nack()
 					}

--- a/main.go
+++ b/main.go
@@ -2,9 +2,10 @@ package main
 
 import (
 	"bytes"
-	"cloud.google.com/go/pubsub"
 	"context"
 	"encoding/csv"
+
+	"cloud.google.com/go/pubsub"
 	"github.com/blendle/zapdriver"
 	"github.com/spf13/viper"
 	"go.uber.org/zap"

--- a/main_test.go
+++ b/main_test.go
@@ -44,7 +44,7 @@ func TestSubscribe(t *testing.T) {
 
 	sampleJson := parseSample(err, assert)
 
-	sampleServer := httptest.NewServer(http.HandlerFunc( func(w http.ResponseWriter, r *http.Request) {
+	sampleServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body, err := io.ReadAll(r.Body)
 		assert.Nil(err)
 		assert.Equal(sampleJson, body)
@@ -52,7 +52,7 @@ func TestSubscribe(t *testing.T) {
 		w.Write([]byte("{\"id\":\"1111\"}"))
 	}))
 
-	partyServer := httptest.NewServer(http.HandlerFunc( func(w http.ResponseWriter, r *http.Request) {
+	partyServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusCreated)
 		w.Write([]byte("{\"id\":\"1111\"}"))
 	}))
@@ -100,7 +100,7 @@ func parseSample(err error, assert *assert.Assertions) []byte {
 	return sampleJson
 }
 
-func createSubscription(client *pubsub.Client, ctx  context.Context, err error, topic *pubsub.Topic, assert *assert.Assertions) *pubsub.Subscription {
+func createSubscription(client *pubsub.Client, ctx context.Context, err error, topic *pubsub.Topic, assert *assert.Assertions) *pubsub.Subscription {
 	sub, err := client.CreateSubscription(ctx, "sample-file", pubsub.SubscriptionConfig{
 		Topic: topic,
 	})
@@ -110,7 +110,7 @@ func createSubscription(client *pubsub.Client, ctx  context.Context, err error, 
 	return sub
 }
 
-func createTopic(client *pubsub.Client, ctx  context.Context, assert *assert.Assertions) (*pubsub.Topic, error) {
+func createTopic(client *pubsub.Client, ctx context.Context, assert *assert.Assertions) (*pubsub.Topic, error) {
 	topic, err := client.CreateTopic(ctx, "sample-file")
 	assert.Nil(err)
 	assert.NotNil(topic)
@@ -157,9 +157,9 @@ func TestNoAckAsSampleSummaryIdMissing(t *testing.T) {
 	//sleep a second for the test to complete, then allow everything to shut down
 	time.Sleep(1 * time.Second)
 
-	messages:= srv.Messages()
+	messages := srv.Messages()
 	//check there is a single message
-	assert.Equal(len(messages),  1, "should have been a single message sent to the server")
+	assert.Equal(len(messages), 1, "should have been a single message sent to the server")
 
 	//and check it hasn't been ack
 	assert.Equal(0, messages[0].Acks)

--- a/party.go
+++ b/party.go
@@ -159,7 +159,7 @@ func (p Party) sendHttpRequest(url string, payload []byte) error {
 		DisableKeepAlives:   false,
 		MaxIdleConns:        100,
 		MaxIdleConnsPerHost: 10,
-		IdleConnTimeout:     1000 * time.Millisecond, // Gunicorn closes idle connections after 2 secs
+		IdleConnTimeout:     1500 * time.Millisecond, // Gunicorn closes idle connections after 2 secs
 	}
 
 	client := &http.Client{

--- a/party.go
+++ b/party.go
@@ -156,7 +156,7 @@ func (p Party) sendHttpRequest(url string, payload []byte) error {
 	password := viper.GetString("SECURITY_USER_PASSWORD")
 
 	transport := &http.Transport{
-		DisableKeepAlives:   true,
+		DisableKeepAlives:   false,
 		MaxIdleConns:        100,
 		MaxIdleConnsPerHost: 10,
 		IdleConnTimeout:     1500 * time.Millisecond, // Gunicorn closes idle connections after 2 secs

--- a/party.go
+++ b/party.go
@@ -2,15 +2,17 @@ package main
 
 import (
 	"bytes"
-	"cloud.google.com/go/pubsub"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/spf13/viper"
-	"go.uber.org/zap"
 	"io"
 	"net/http"
 	"strconv"
+	"time"
+
+	"cloud.google.com/go/pubsub"
+	"github.com/spf13/viper"
+	"go.uber.org/zap"
 )
 
 type Party struct {
@@ -152,7 +154,18 @@ func (p Party) getPartyServiceUrl() string {
 func (p Party) sendHttpRequest(url string, payload []byte) error {
 	username := viper.GetString("SECURITY_USER_NAME")
 	password := viper.GetString("SECURITY_USER_PASSWORD")
-	client := &http.Client{}
+
+	transport := &http.Transport{
+		DisableKeepAlives:   false,
+		MaxIdleConns:        100,
+		MaxIdleConnsPerHost: 10,
+		IdleConnTimeout:     1500 * time.Millisecond, // Gunicorn closes idle connections after 2 secs
+	}
+
+	client := &http.Client{
+		Transport: transport,
+		Timeout:   30 * time.Second,
+	}
 	req, err := http.NewRequest("POST", url, bytes.NewReader(payload))
 	if err != nil {
 		logger.Error("error creating HTTP request", zap.Error(err))
@@ -178,7 +191,7 @@ func (p Party) sendHttpRequest(url string, payload []byte) error {
 	} else if resp.StatusCode == http.StatusConflict {
 		logger.Warn("party already exists", zap.String("sampleUnitRef", p.SAMPLEUNITREF), zap.String("messageId", p.msg.ID))
 		return nil
-	}  else {
+	} else {
 		logger.Error("party not created", zap.Int("status code", resp.StatusCode), zap.String("sampleUnitRef", p.SAMPLEUNITREF), zap.String("messageId", p.msg.ID))
 		return errors.New(fmt.Sprintf("sample not created - status code %d", resp.StatusCode))
 	}

--- a/party.go
+++ b/party.go
@@ -156,7 +156,7 @@ func (p Party) sendHttpRequest(url string, payload []byte) error {
 	password := viper.GetString("SECURITY_USER_PASSWORD")
 
 	transport := &http.Transport{
-		DisableKeepAlives:   false,
+		DisableKeepAlives:   true,
 		MaxIdleConns:        100,
 		MaxIdleConnsPerHost: 10,
 		IdleConnTimeout:     1500 * time.Millisecond, // Gunicorn closes idle connections after 2 secs

--- a/party.go
+++ b/party.go
@@ -159,7 +159,7 @@ func (p Party) sendHttpRequest(url string, payload []byte) error {
 		DisableKeepAlives:   false,
 		MaxIdleConns:        100,
 		MaxIdleConnsPerHost: 10,
-		IdleConnTimeout:     1500 * time.Millisecond, // Gunicorn closes idle connections after 2 secs
+		IdleConnTimeout:     1000 * time.Millisecond, // Gunicorn closes idle connections after 2 secs
 	}
 
 	client := &http.Client{

--- a/party.go
+++ b/party.go
@@ -159,7 +159,7 @@ func (p Party) sendHttpRequest(url string, payload []byte) error {
 		DisableKeepAlives:   false,
 		MaxIdleConns:        100,
 		MaxIdleConnsPerHost: 10,
-		IdleConnTimeout:     4000 * time.Millisecond, // Gunicorn closes idle connections after 2 secs
+		IdleConnTimeout:     1500 * time.Millisecond, // Gunicorn closes idle connections after 2 secs
 	}
 
 	client := &http.Client{
@@ -175,7 +175,7 @@ func (p Party) sendHttpRequest(url string, payload []byte) error {
 	req.Header.Add("content-type", "application/json")
 	resp, err := client.Do(req)
 	if err != nil {
-		logger.Error("error sending HTTP request", zap.Error(err))
+		logger.Warn("error sending HTTP request", zap.Error(err))
 		return err
 	}
 	defer resp.Body.Close()

--- a/party.go
+++ b/party.go
@@ -159,7 +159,7 @@ func (p Party) sendHttpRequest(url string, payload []byte) error {
 		DisableKeepAlives:   false,
 		MaxIdleConns:        100,
 		MaxIdleConnsPerHost: 10,
-		IdleConnTimeout:     1500 * time.Millisecond, // Gunicorn closes idle connections after 2 secs
+		IdleConnTimeout:     4000 * time.Millisecond, // Gunicorn closes idle connections after 2 secs
 	}
 
 	client := &http.Client{

--- a/party_test.go
+++ b/party_test.go
@@ -63,7 +63,6 @@ func TestPartyConflict(t *testing.T) {
 	assert.Nil(err, "error should be nil")
 }
 
-
 func TestPartyError(t *testing.T) {
 	assert := assert.New(t)
 	ts := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -99,7 +98,6 @@ func TestPartyServerURL(t *testing.T) {
 
 	assert.Equal("https://127.0.0.1/party-api/v1/parties", p.getPartyServiceUrl())
 }
-
 
 func TestPartySendHttpRequest(t *testing.T) {
 	p := &Party{}

--- a/sample.go
+++ b/sample.go
@@ -2,13 +2,14 @@ package main
 
 import (
 	"bytes"
-	"cloud.google.com/go/pubsub"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"go.uber.org/zap"
 	"io"
 	"net/http"
+
+	"cloud.google.com/go/pubsub"
+	"go.uber.org/zap"
 
 	"github.com/spf13/viper"
 )
@@ -156,7 +157,7 @@ func (s Sample) sendHttpRequest(url string, payload []byte) (string, error) {
 		}
 		return sampleUnitId, nil
 	} else if resp.StatusCode == http.StatusConflict {
-		logger.Warn("attempted to create duplicate sample", zap.Int("status code", resp.StatusCode), zap.String("sampleUnitRef", s.SAMPLEUNITREF), zap.String("messageId", s.msg.ID))
+		logger.Warn("attempted to create duplicate sample unit", zap.Int("status code", resp.StatusCode), zap.String("sampleUnitRef", s.SAMPLEUNITREF), zap.String("messageId", s.msg.ID))
 		// if this sample unit has already been created attempt to retrieve the sample unit id
 		return s.getSampleUnitID()
 	} else {

--- a/sample_test.go
+++ b/sample_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-
 func TestSampleSuccess(t *testing.T) {
 	assert := assert.New(t)
 	ts := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
# What and why?
Adding in some configuration to make go clean up its idle connections to party before party closes them without telling csv worker. This doesn't solve the issue completely, but it should stabilise the connections a bit and highlight unrecoverable errors as errors by making these warnings

N.B. I am also seeing OOMemory restarts in dev but this may not be representative when the service is fully scaled up in our other environments
# How to test?
Probably best to test this in performance with a large sample (~200k) but you can test it in dev as well with something around 10k. Make sure that the error logs are now warnings and that fewer idle connection logs appear
# Jira
https://officefornationalstatistics.atlassian.net/browse/RAS-1828